### PR TITLE
Parameterize build_image and e2e_image

### DIFF
--- a/codebuild.tf
+++ b/codebuild.tf
@@ -26,7 +26,7 @@ resource "aws_codebuild_project" "build" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:2.0"
+    image                       = var.build_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"
@@ -112,7 +112,7 @@ resource "aws_codebuild_project" "e2e_tests" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "cypress/browsers:chrome69"
+    image                       = var.e2e_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"
@@ -199,7 +199,7 @@ resource "aws_codebuild_project" "unit_tests" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:2.0"
+    image                       = var.build_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"
@@ -286,7 +286,7 @@ resource "aws_codebuild_project" "publish" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:2.0"
+    image                       = var.build_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"
@@ -373,7 +373,7 @@ resource "aws_codebuild_project" "db_migrate" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:2.0"
+    image                       = var.build_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"
@@ -460,7 +460,7 @@ resource "aws_codebuild_project" "update_service" {
 
   environment {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/standard:2.0"
+    image                       = var.build_image
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -137,3 +137,15 @@ variable "task_role_arn" {
   description = "IAM role for task to run as"
   default     = ""
 }
+
+variable "build_image" {
+  type        = string
+  default     = "aws/codebuild/standard:3.0"
+  description = "Docker image for build stages"
+}
+
+variable "e2e_image" {
+  type        = string
+  default     = "cypress/browsers:chrome69"
+  description = "Docker image for e2e stages"
+}


### PR DESCRIPTION
Also bump default codebuild image from :2.0 to :3.0 as :2.0 is no longer maintained as of July 2020. https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html